### PR TITLE
Use UTF-8 filenames for any browser except Internet Explorer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ branches:
   only:
     - master
 
+before_install:
+    - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then pecl install xdebug; fi;
+
 install:
   - composer install --dev --no-interaction
 

--- a/src/TarStreamer.php
+++ b/src/TarStreamer.php
@@ -57,10 +57,17 @@ class TarStreamer {
 			'Accept-Ranges' => 'bytes',
 			'Connection' => 'Keep-Alive',
 			'Content-Type' => $contentType,
-			'Content-Disposition' => 'attachment; filename="' . $encodedArchiveName . '";',
 			'Cache-Control' => 'public, must-revalidate',
 			'Content-Transfer-Encoding' => 'binary',
 		];
+
+		// Use UTF-8 filenames when not using Internet Explorer
+		if(strpos($_SERVER['HTTP_USER_AGENT'], 'MSIE') > 0) {
+			header('Content-Disposition: attachment; filename="' . rawurlencode($archiveName) . '"');
+		}  else  {
+			header('Content-Disposition: attachment; filename*=UTF-8\'\'' . rawurlencode($archiveName)
+					. '; filename="' . rawurlencode($archiveName) . '"');
+		}
 
 		foreach ($headers as $key => $value){
 			header("$key: $value");


### PR DESCRIPTION
Otherwise archives such as `1 (234).tar` would be downloaded as `1 %28234%29.tar`.

Ref https://github.com/owncloud/core/issues/19862
