### PR TITLE
[0.2.0] Add PHP 7.3 to the matrix, drop PHP 5.4, 5.5, 5.6, 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
-dist: trusty
 language: php
 php:
-#  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 branches:
   only:


### PR DESCRIPTION
Drop PHP 5.4, 5.5, 5.6, 7.0
Add PHP 7.3

### TODO
- [ ] review composer dependency versions
- [ ] bump required PHP version to 7.1
