### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: php
 php:
 #  - 5.3
@@ -12,16 +13,13 @@ branches:
   only:
     - master
 
-before_install:
-    - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then pecl install xdebug; fi;
-
 install:
   - composer install --dev --no-interaction
 
 script:
   - mkdir -p build/logs
   - cd tests
-  - phpunit --coverage-clover ../build/logs/clover.xml --configuration phpunit.xml
+  - ../vendor/bin/phpunit --coverage-clover ../build/logs/clover.xml --configuration phpunit.xml
 
 after_script:
   # Create coverage report


### PR DESCRIPTION
Do not try to install xdebug, use phpunit from dependencies
`dist:trusty` is needed for 5.4 and 5.5 to succeed.