### PR TITLE
Force explicit int cast for decoct in PHP8

### DIFF
--- a/src/TarHeader.php
+++ b/src/TarHeader.php
@@ -68,8 +68,8 @@ class TarHeader {
 			['a8', str_pad($this->mode, 7, '0', STR_PAD_LEFT)],
 			['a8', decoct(str_pad($this->uid, 7, '0', STR_PAD_LEFT))],
 			['a8', decoct(str_pad($this->gid, 7, '0', STR_PAD_LEFT))],
-			['a12', str_pad(decoct($this->size), 11, '0', STR_PAD_LEFT)],
-			['a12', str_pad(decoct($this->mtime), 11, '0', STR_PAD_LEFT)],
+			['a12', str_pad(decoct((int)$this->size), 11, '0', STR_PAD_LEFT)],
+			['a12', str_pad(decoct((int)$this->mtime), 11, '0', STR_PAD_LEFT)],
 			// We calculate checksum later
 			['a8', ''],
 			['a1', $this->typeflag],


### PR DESCRIPTION
In PHP8 at least, the lack of cast was causing large values to be read as strings, causing errors such as this one: https://github.com/owncloud/TarStreamer/issues/23#issuecomment-1449700060

In my case, this happened when a large file had to be added to the Tar archive. Forcing the (int) cast seems to have fixed it for me, and the files are downloaded correctly. I don't expect any issues with PHP7 either, but please review if it's acceptable or if there's any other area where this would fit best.

Thanks.