### PR TITLE
Don't stop reading if fread returns an empty string

### DIFF
--- a/src/TarStreamer.php
+++ b/src/TarStreamer.php
@@ -101,7 +101,7 @@ class TarStreamer {
 		$this->initFileStreamTransfer($filePath, self::REGTYPE, $size, $options);
 
 		// send file blocks
-		while ($data = fread($stream, $this->blockSize)) {
+		while (!feof($stream) && ($data = fread($stream, $this->blockSize)) !== false) {
 			// send data
 			$this->streamFilePart($data);
 		}


### PR DESCRIPTION
This fixes a premature loop termination on empty string read, which can happen when reading from network streams, leading to packing truncated files silently.

By explicitly checking against "false", the loop will terminate only if fread returns a failure.

Fixes https://github.com/owncloud/TarStreamer/issues/31 with a minimally invasive change.